### PR TITLE
Receipt Service Improvements

### DIFF
--- a/PSIShoppingEngine/DTOs/Reciept/AddReceiptDto.cs
+++ b/PSIShoppingEngine/DTOs/Reciept/AddReceiptDto.cs
@@ -9,6 +9,5 @@ namespace PSIShoppingEngine.DTOs.Reciept
     public class AddReceiptDto
     {
         public Shop Shop { get; set; }
-        public int UserId { get; set; }
     }
 }

--- a/PSIShoppingEngine/Models/ItemPrice.cs
+++ b/PSIShoppingEngine/Models/ItemPrice.cs
@@ -11,7 +11,7 @@ namespace PSIShoppingEngine.Models
         public int ItemId { get; set; }
         public Item Item { get; set; }
         public double Price { get; set; }
-        public int ReceiptId { get; set; }
+        public int? ReceiptId { get; set; }
         public Receipt Receipt { get; set; }
 
     }

--- a/PSIShoppingEngine/Services/ReceiptService/ReceiptService.cs
+++ b/PSIShoppingEngine/Services/ReceiptService/ReceiptService.cs
@@ -32,6 +32,7 @@ namespace PSIShoppingEngine.Services.ReceiptService
             ServiceResponse<List<GetReceiptDto>> serviceResponse = new ServiceResponse<List<GetReceiptDto>>();
             
             var receipt = _mapper.Map<Receipt>(newReceipt);
+            receipt.UserId = GetUserId();
             await _context.Receipts.AddAsync(receipt);
             await _context.SaveChangesAsync();
             serviceResponse.Data = (_context.Receipts.Where(c => c.User.Id == GetUserId()).Select(c => _mapper.Map<GetReceiptDto>(c))).ToList();


### PR DESCRIPTION
Remove the need to send a UserId when creating a new receipt, changed receiptId to nullable.